### PR TITLE
Default to light theme with dark mode toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Session Log
 - 2024-04-XX: Initial visit by AI agent `gpt-5-codex`. Created this working memory file and README scaffolding. Intent is to document actions, reasoning, and future to-dos for subsequent agents.
+- 2024-05-21: Updated UI to default to light mode with a dark-mode toggle and refreshed footer attribution link.
 
 ## Notes for Future Agents
 - Keep this log updated with each visit; append new entries with ISO dates and brief rationale.

--- a/index.html
+++ b/index.html
@@ -29,6 +29,23 @@
 
   <style>
     :root{
+      color-scheme: light;
+      --bg: #f6f7fb;
+      --panel: #ffffff;
+      --muted: #5d6578;
+      --text: #1a1e2b;
+      --accent: #2f5ce5;
+      --border: #d6dcef;
+      --chip: #eef1fb;
+      --input-bg: #f5f7ff;
+      --header-bg: #ffffff;
+      --toolbar-bg: #f1f3fb;
+      --editor-bg: #ffffff;
+      --ok: #1a9a63;
+      --warn: #c98200;
+    }
+    body[data-theme="dark"]{
+      color-scheme: dark;
       --bg: #0b0c10;
       --panel: #121318;
       --muted: #a8b3cf;
@@ -36,6 +53,10 @@
       --accent: #6aa6ff;
       --border: #1f2330;
       --chip: #1a1d26;
+      --input-bg: #0e1016;
+      --header-bg: #0d0f15;
+      --toolbar-bg: #0e1016;
+      --editor-bg: #0f1118;
       --ok: #3ecf8e;
       --warn: #ffd166;
     }
@@ -48,24 +69,39 @@
       color: var(--text);
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
+      transition: background 0.3s ease, color 0.3s ease;
     }
     a{ color: var(--accent); text-decoration: none; }
     header{
       padding: 16px 20px;
       border-bottom: 1px solid var(--border);
       display:flex; align-items:center; gap:16px; justify-content:space-between;
-      background: #0d0f15;
+      background: var(--header-bg);
       position: sticky; top:0; z-index: 30;
     }
-    .brand{
-      display:flex; align-items:center; gap:12px; font-weight:700; letter-spacing:.2px;
+    .brand-title{
+      margin:0;
+      font-weight:700;
+      font-size: clamp(1.1rem, 2vw, 1.4rem);
+      letter-spacing: .3px;
     }
-    .logo{
-      width:28px; height:28px; border-radius:8px;
-      background: linear-gradient(145deg, #7bb9ff, #4a73ff);
-      display:inline-flex; align-items:center; justify-content:center;
-      color: #0b0c10;
-      font-weight:800;
+    .theme-toggle{
+      border:1px solid var(--border);
+      background: var(--input-bg);
+      color: var(--text);
+      padding:10px 14px;
+      border-radius:999px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+    .theme-toggle:hover{
+      transform: translateY(-1px);
+    }
+    .theme-toggle:focus-visible{
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
     .wrap{
       padding: 20px;
@@ -81,19 +117,20 @@
       border: 1px solid var(--border);
       border-radius: 12px;
       padding: 16px;
+      transition: background 0.3s ease, border-color 0.3s ease;
     }
     .toolbar{
       display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-bottom:12px;
     }
     .toolbar .btn, .toolbar label.btn{
-      border:1px solid var(--border); background:#0e1016; color:var(--text);
+      border:1px solid var(--border); background:var(--toolbar-bg); color:var(--text);
       padding:10px 12px; border-radius:10px; font-size:14px; cursor:pointer;
     }
     .toolbar input[type="file"]{ display:none; }
     .toolbar .grow{ flex:1; min-width: 260px; }
     .toolbar input[type="url"]{
       width:100%; padding:10px 12px; border:1px solid var(--border);
-      border-radius:10px; background:#0e1016; color:var(--text);
+      border-radius:10px; background:var(--input-bg); color:var(--text);
     }
     .toolbar .help{
       font-size:12px; color: var(--muted); margin-top:6px;
@@ -106,6 +143,7 @@
     .metric{
       padding:12px; background: var(--chip);
       border:1px solid var(--border); border-radius:10px;
+      transition: background 0.3s ease, border-color 0.3s ease;
     }
     .metric .label{ font-size:12px; color: var(--muted); }
     .metric .value{ font-size:20px; font-weight:700; margin-top:6px; }
@@ -120,7 +158,7 @@
     .options .row{ display:flex; gap:8px; align-items:center; margin-bottom:8px; }
     .options input[type="text"], .options textarea, .options select{
       width:100%; padding:10px 12px; border:1px solid var(--border);
-      border-radius:10px; background:#0e1016; color:var(--text); resize:vertical;
+      border-radius:10px; background:var(--input-bg); color:var(--text); resize:vertical;
     }
     .options textarea{ min-height: 70px; }
 
@@ -131,7 +169,7 @@
     }
     .badge{
       display:inline-block; padding:2px 8px; border-radius:999px; border:1px solid var(--border);
-      background:#0e1016; color:var(--muted); font-size:11px;
+      background:var(--toolbar-bg); color:var(--muted); font-size:11px;
     }
     .ok{ color: var(--ok); }
     .warn{ color: var(--warn); }
@@ -140,12 +178,12 @@
     #editor-card{ padding:0; overflow: hidden; }
     #editor-toolbar{
       border-bottom:1px solid var(--border);
-      background:#0e1016;
+      background:var(--toolbar-bg);
     }
     #editor{
       height: 55vh;
       max-height: 70vh;
-      background:#0f1118;
+      background:var(--editor-bg);
       border:none;
       color: var(--text);
     }
@@ -153,21 +191,19 @@
     .ql-snow.ql-toolbar button, .ql-snow .ql-picker-label{ color: var(--text); }
     .ql-container.ql-snow{ border: none; }
     .ql-toolbar.ql-snow{ border: none; }
-    .footer-note{ color: var(--muted); font-size:12px; margin-top:8px; }
+    .footer-note{ color: var(--muted); font-size:12px; margin-top:12px; }
+    .footer-note a{ color: var(--accent); font-weight:600; }
     .kbd{
       font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
       padding:2px 6px; border:1px solid var(--border); border-bottom-width:3px;
-      border-radius:6px; background:#0e1016; font-size:12px;
+      border-radius:6px; background:var(--toolbar-bg); font-size:12px;
     }
   </style>
 </head>
-<body>
+<body data-theme="light">
   <header>
-    <div class="brand">
-      <div class="logo">S</div>
-      <div>Sounny</div>
-    </div>
-    <div class="badge">Word Counter</div>
+    <h1 class="brand-title">Sounny's Word Counter</h1>
+    <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Dark mode</button>
   </header>
 
   <div class="wrap">
@@ -257,8 +293,8 @@
       </div>
 
       <div class="footer-note">
-        Sounny updates all values as you type.  
-        Keyboard tip: press <span class="kbd">Ctrl</span> + <span class="kbd">B</span> for bold, <span class="kbd">Ctrl</span> + <span class="kbd">I</span> for italic.
+        Made with <span aria-hidden="true">❤️</span> by
+        <a href="https://sounny.githuh.io" target="_blank" rel="noreferrer">sounny</a>.
       </div>
     </aside>
 
@@ -315,6 +351,39 @@
     const fetchGdocBtn = el('fetch-gdoc');
     const gdocHint = el('gdoc-export-hint');
     const sampleBtn = el('paste-sample');
+    const themeToggleBtn = el('theme-toggle');
+
+    const THEME_STORAGE_KEY = 'sounny-theme';
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const setTheme = theme => {
+      const normalized = theme === 'dark' ? 'dark' : 'light';
+      document.body.dataset.theme = normalized;
+      themeToggleBtn.textContent = normalized === 'dark' ? 'Light mode' : 'Dark mode';
+      themeToggleBtn.setAttribute('aria-pressed', String(normalized === 'dark'));
+    };
+
+    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    const initialTheme = savedTheme || (prefersDark.matches ? 'dark' : 'light');
+    setTheme(initialTheme);
+
+    themeToggleBtn.addEventListener('click', () => {
+      const nextTheme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+      setTheme(nextTheme);
+      localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    });
+
+    const handlePrefersDarkChange = event => {
+      if (!localStorage.getItem(THEME_STORAGE_KEY)){
+        setTheme(event.matches ? 'dark' : 'light');
+      }
+    };
+
+    if (typeof prefersDark.addEventListener === 'function'){
+      prefersDark.addEventListener('change', handlePrefersDarkChange);
+    } else if (typeof prefersDark.addListener === 'function'){
+      prefersDark.addListener(handlePrefersDarkChange);
+    }
 
     const metricsEls = {
       words: el('m-words'),


### PR DESCRIPTION
## Summary
- set the app to use a light color palette by default while keeping dark-theme variables
- add a header toggle to switch themes and update the footer attribution link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4dbe83b4c8327997ee365b85851be